### PR TITLE
Upgrade rspec

### DIFF
--- a/brewdler.gemspec
+++ b/brewdler.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'commander'
   gem.add_dependency 'mime-types', '1.25'
-  gem.add_development_dependency 'rspec', '~> 2.99.0'
+  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'coveralls'

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -4,9 +4,9 @@ describe Brewdler::Dsl do
   let(:dsl) { Brewdler::Dsl.new("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'\nbrew 'emacs', args: ['cocoa', 'srgb', 'with-gnutls']") }
 
   it "processes input" do
-    dsl.should_receive(:tap).with('phinze/cask')
-    dsl.should_receive(:brew).twice
-    dsl.should_receive(:cask).with('google-chrome')
+    expect(dsl).to receive(:tap).with('phinze/cask')
+    expect(dsl).to receive(:brew).twice
+    expect(dsl).to receive(:cask).with('google-chrome')
     dsl.process
   end
 end

--- a/spec/install_command_spec.rb
+++ b/spec/install_command_spec.rb
@@ -9,14 +9,16 @@ describe Brewdler::Commands::Install do
 
   context "when a Brewfile is found" do
     it "does not raise an error" do
-      Brewdler::BrewInstaller.stub(:install).and_return(true)
-      Brewdler::CaskInstaller.stub(:install).and_return(true)
-      Brewdler::RepoInstaller.stub(:install).and_return(true)
+      allow(Brewdler::BrewInstaller).to receive(:install).and_return(true)
+      allow(Brewdler::CaskInstaller).to receive(:install).and_return(true)
+      allow(Brewdler::RepoInstaller).to receive(:install).and_return(true)
 
-      File.stub(:read).and_return("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'")
+      allow(File).to receive(:read).
+        and_return("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'")
       expect { Brewdler::Commands::Install.run }.to_not raise_error
 
-      File.stub(:read => 'git', :open => ['git'])
+      allow(File).to receive(:read).and_return('git')
+      allow(File).to receive(:open).and_return('git')
       expect { Brewdler::Commands::Install.run }.to_not raise_error
     end
   end


### PR DESCRIPTION
- Replace deprecated `should_receive` with `expect(...).to ...`
- Replace deprecated `stub` with `allow(...).to receive(...)`