### PR TITLE
Remove mime-types dependency

### DIFF
--- a/brewdler.gemspec
+++ b/brewdler.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency 'commander'
-  gem.add_dependency 'mime-types', '1.25'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
I have no idea why this was added in 99dab3359f3fa602fac63487703268ab83232392. Its not used by this library at all.

cc @andrew @jamesaanderson 