### PR TITLE
Detect presence of brew and brew-cask commands

### DIFF
--- a/lib/brewdler/brew_installer.rb
+++ b/lib/brewdler/brew_installer.rb
@@ -1,7 +1,7 @@
 module Brewdler
   class BrewInstaller
     def self.install(name, options = {})
-      if system 'brew info'
+      if `which brew`; $?.success?
         command = "brew install #{name}"
         unless options[:args].nil?
           options[:args].each do |arg|

--- a/lib/brewdler/cask_installer.rb
+++ b/lib/brewdler/cask_installer.rb
@@ -1,7 +1,7 @@
 module Brewdler
   class CaskInstaller
     def self.install(name)
-      if system "brew cask info #{name}"
+      if `which brew-cask`; $?.success?
         `brew cask install #{name}`
       else
         raise "Unable to install #{name}. Homebrew-cask is not currently installed on your system"

--- a/lib/brewdler/repo_installer.rb
+++ b/lib/brewdler/repo_installer.rb
@@ -1,7 +1,7 @@
 module Brewdler
   class RepoInstaller
     def self.install(name)
-      if system 'brew tap'
+      if `which brew`; $?.success?
         `brew tap #{name}`
       else
         raise "Unable to tap #{name}. Homebrew is not currently installed on your system"


### PR DESCRIPTION
Simply checks if `brew` or `brew-cask` load path rather than trying to execute and dump the output of expensive commands.

Invoking `brew info` on my machine adds an additional 2 seconds to every brew install and prints useless data like `35 kegs, 91540 files, 1.4G` to the output.

cc @mikemcquaid