### PR TITLE
Change eval to instance_eval

### DIFF
--- a/lib/brewdler/dsl.rb
+++ b/lib/brewdler/dsl.rb
@@ -5,7 +5,7 @@ module Brewdler
     end
 
     def process
-      eval(@input)
+      instance_eval(@input)
     end
 
     def brew(name, options={})


### PR DESCRIPTION
I think we should keep #32 open for now but I changed `eval` to `instance_eval` which should be a bit more secure. Bundler seems to use `instance_eval` as well.