### PR TITLE
eliminate warning during the test

### DIFF
--- a/spec/brewdumper_spec.rb
+++ b/spec/brewdumper_spec.rb
@@ -27,6 +27,7 @@ describe Brewdler::BrewDumper do
   context "formulae `foo` and `bar` are installed" do
     before do
       allow(Brewdler).to receive(:brew_installed?).and_return(true)
+      allow_any_instance_of(Brewdler::BrewDumper).to receive(:`)
       allow(JSON).to receive(:load).and_return [
         {
           "name" => "foo",
@@ -56,6 +57,7 @@ describe Brewdler::BrewDumper do
   context "HEAD and devel formulae are installed" do
     before do
       allow(Brewdler).to receive(:brew_installed?).and_return(true)
+      allow_any_instance_of(Brewdler::BrewDumper).to receive(:`)
       allow(JSON).to receive(:load).and_return [
         {
           "name" => "foo",
@@ -82,6 +84,7 @@ describe Brewdler::BrewDumper do
   context "A formula link to the old keg" do
     before do
       allow(Brewdler).to receive(:brew_installed?).and_return(true)
+      allow_any_instance_of(Brewdler::BrewDumper).to receive(:`)
       allow(JSON).to receive(:load).and_return [
         {
           "name" => "foo",
@@ -104,6 +107,7 @@ describe Brewdler::BrewDumper do
   context "A formula with no linked keg" do
     before do
       allow(Brewdler).to receive(:brew_installed?).and_return(true)
+      allow_any_instance_of(Brewdler::BrewDumper).to receive(:`)
       allow(JSON).to receive(:load).and_return [
         {
           "name" => "foo",

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -3,21 +3,19 @@ require "spec_helper"
 describe Brewdler::Commands::Dump do
   context "when files existed" do
     before do
-      allow(Brewdler).to receive(:brew_installed?).and_return(true)
-      allow(Brewdler).to receive(:cask_installed?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(ARGV).to receive(:force?).and_return(false)
     end
 
     it "raises error" do
-      expect { Brewdler::Commands::Dump.run }.to raise_error
+      expect do
+        Bundler.with_clean_env { Brewdler::Commands::Dump.run }
+      end.to raise_error
     end
   end
 
   context "when files existed and `--force` is passed" do
     before do
-      allow(Brewdler).to receive(:brew_installed?).and_return(true)
-      allow(Brewdler).to receive(:cask_installed?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:file?).and_return(true)
       allow(ARGV).to receive(:force?).and_return(true)
@@ -26,7 +24,9 @@ describe Brewdler::Commands::Dump do
     it "doesn't raise error" do
       expect(FileUtils).to receive(:rm)
       expect_any_instance_of(Pathname).to receive(:write)
-      expect { Brewdler::Commands::Dump.run }.to_not raise_error
+      expect do
+        Bundler.with_clean_env { Brewdler::Commands::Dump.run }
+      end.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
This commit fixes the following warning when invoking `bundle exec rake`

    Could not find rake-10.4.2 in any of the sources (Bundler::GemNotFound)