### PR TITLE
allowing custom Brewfile path in the argument

### DIFF
--- a/cmd/brew-brewdle.rb
+++ b/cmd/brew-brewdle.rb
@@ -8,9 +8,9 @@ $LOAD_PATH.unshift(BREWDLER_LIB)
 require "brewdler"
 
 usage = <<-EOS.undent
-  brew brewdle [-v|--verbose] [--file=<path>]
-  brew brewdle dump [--force] [--file=<path>]
-  brew brewdle cleanup [--dry-run] [--file=<path>]
+  brew brewdle [-v|--verbose] [--file=<path>|--global]
+  brew brewdle dump [--force] [--file=<path>|--global]
+  brew brewdle cleanup [--dry-run] [--file=<path>|--global]
   brew brewdle [--version]
   brew brewdle [-h|--help]
 
@@ -26,6 +26,7 @@ usage = <<-EOS.undent
   --force                force overwrite existed Brewfile
   --dry-run              list formulae rather than actual uninstalling them
   --file=<path>          set Brewfile path
+  --global               set Brewfile path to $HOME/.Brewfile
   -h, --help             show this help message and exit
   --version              show the version of brewdler
 EOS

--- a/cmd/brew-brewdle.rb
+++ b/cmd/brew-brewdle.rb
@@ -8,9 +8,9 @@ $LOAD_PATH.unshift(BREWDLER_LIB)
 require "brewdler"
 
 usage = <<-EOS.undent
-  brew brewdle [-v|--verbose]
-  brew brewdle dump [--force]
-  brew brewdle cleanup [--dry-run]
+  brew brewdle [-v|--verbose] [--file=<path>]
+  brew brewdle dump [--force] [--file=<path>]
+  brew brewdle cleanup [--dry-run] [--file=<path>]
   brew brewdle [--version]
   brew brewdle [-h|--help]
 
@@ -25,6 +25,7 @@ usage = <<-EOS.undent
   -v, --verbose          print verbose output
   --force                force overwrite existed Brewfile
   --dry-run              list formulae rather than actual uninstalling them
+  --file=<path>          set Brewfile path
   -h, --help             show this help message and exit
   --version              show the version of brewdler
 EOS

--- a/lib/brewdler/dumper.rb
+++ b/lib/brewdler/dumper.rb
@@ -12,8 +12,9 @@ module Brewdler
     end
 
     def dump_brewfile
+      file = Pathname.new(ARGV.value("file") || "Brewfile").expand_path(Dir.pwd)
       content = [repo, brew, cask].map(&:to_s).reject(&:empty?).join("\n") + "\n"
-      write_file Pathname.new(Dir.pwd).join("Brewfile"), content, ARGV.force?
+      write_file file, content, ARGV.force?
     end
 
     private

--- a/lib/brewdler/dumper.rb
+++ b/lib/brewdler/dumper.rb
@@ -12,7 +12,11 @@ module Brewdler
     end
 
     def dump_brewfile
-      file = Pathname.new(ARGV.value("file") || "Brewfile").expand_path(Dir.pwd)
+      if ARGV.include?("--global")
+        file = Pathname.new("#{ENV["HOME"]}/.Brewfile")
+      else
+        file = Pathname.new(ARGV.value("file") || "Brewfile").expand_path(Dir.pwd)
+      end
       content = [repo, brew, cask].map(&:to_s).reject(&:empty?).join("\n") + "\n"
       write_file file, content, ARGV.force?
     end

--- a/lib/brewdler/utils.rb
+++ b/lib/brewdler/utils.rb
@@ -25,7 +25,11 @@ module Brewdler
   end
 
   def self.brewfile
-    file = ARGV.value("file") || Dir["{*,.*}{B,b}rewfile"].first.to_s
+    if ARGV.include?("--global")
+      file = "#{ENV["HOME"]}/.Brewfile"
+    else
+      file = ARGV.value("file") || Dir["{*,.*}{B,b}rewfile"].first.to_s
+    end
     File.read(file)
   rescue Errno::ENOENT
     raise "No Brewfile found"

--- a/lib/brewdler/utils.rb
+++ b/lib/brewdler/utils.rb
@@ -25,7 +25,8 @@ module Brewdler
   end
 
   def self.brewfile
-    File.read(Dir['{*,.*}{B,b}rewfile'].first.to_s)
+    file = ARGV.value("file") || Dir["{*,.*}{B,b}rewfile"].first.to_s
+    File.read(file)
   rescue Errno::ENOENT
     raise "No Brewfile found"
   end

--- a/spec/cleanup_command_spec.rb
+++ b/spec/cleanup_command_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Brewdler::Commands::Cleanup do
   context "read Brewfile and currently installation" do
     before do
+      allow(ARGV).to receive(:value).and_return(nil)
       allow(File).to receive(:read).and_return("tap 'x'\ntap 'y'\nbrew 'a'\nbrew 'b'")
       allow(Brewdler::Commands::Cleanup).to receive(:`) do |arg|
         case arg

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -5,6 +5,7 @@ describe Brewdler::Commands::Dump do
     before do
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow(ARGV).to receive(:force?).and_return(false)
+      allow(ARGV).to receive(:value).and_return(nil)
     end
 
     it "raises error" do
@@ -19,6 +20,7 @@ describe Brewdler::Commands::Dump do
       allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:file?).and_return(true)
       allow(ARGV).to receive(:force?).and_return(true)
+      allow(ARGV).to receive(:value).and_return(nil)
     end
 
     it "doesn't raise error" do

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -6,6 +6,7 @@ describe Brewdler::Dumper do
     allow(Brewdler).to receive(:brew_installed?).and_return(true)
     allow(Brewdler).to receive(:cask_installed?).and_return(true)
     allow(ARGV).to receive(:force?).and_return(false)
+    allow(ARGV).to receive(:value).and_return(nil)
     allow_any_instance_of(Brewdler::BrewDumper).to receive(:`).and_return("[]")
     allow_any_instance_of(Brewdler::RepoDumper).to receive(:`).and_return("caskroom/cask")
     allow_any_instance_of(Brewdler::CaskDumper).to receive(:`).and_return("google-chrome\njava")
@@ -14,6 +15,7 @@ describe Brewdler::Dumper do
 
   it "generate output" do
     expect(subject).to receive(:write_file) do |file, content, overwrite|
+      expect(file).to eql(Pathname.new(Dir.pwd).join("Brewfile"))
       expect(content).to eql("tap 'caskroom/cask'\ncask 'google-chrome'\ncask 'java'\n")
     end
     subject.dump_brewfile

--- a/spec/install_command_spec.rb
+++ b/spec/install_command_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Brewdler::Commands::Install do
   context "when a Brewfile is not found" do
     it "raises an error" do
+      allow(ARGV).to receive(:value).and_return(nil)
       expect { Brewdler::Commands::Install.run }.to raise_error
     end
   end
@@ -13,6 +14,7 @@ describe Brewdler::Commands::Install do
       allow(Brewdler::CaskInstaller).to receive(:install).and_return(true)
       allow(Brewdler::RepoInstaller).to receive(:install).and_return(true)
 
+      allow(ARGV).to receive(:value).and_return(nil)
       allow(File).to receive(:read).
         and_return("tap 'phinze/cask'\nbrew 'git'\ncask 'google-chrome'")
       expect { Brewdler::Commands::Install.run }.to_not raise_error


### PR DESCRIPTION
It can be useful if there're multiple Brewfile configurations.
e.g.

    brew brewdle --file=Brewfile.osx
    brew brewdle --file=Brewfile.linux