### PR TITLE
resolve path when overwrite Brewfile

### DIFF
--- a/lib/brewdler/dumper.rb
+++ b/lib/brewdler/dumper.rb
@@ -26,6 +26,7 @@ module Brewdler
     def write_file(file, content, overwrite=false)
       if file.exist?
         if overwrite && file.file?
+          file = file.readlink
           FileUtils.rm file
         else
           raise "#{file} already existed."

--- a/spec/dump_command_spec.rb
+++ b/spec/dump_command_spec.rb
@@ -26,6 +26,7 @@ describe Brewdler::Commands::Dump do
     it "doesn't raise error" do
       expect(FileUtils).to receive(:rm)
       expect_any_instance_of(Pathname).to receive(:write)
+      expect_any_instance_of(Pathname).to receive(:readlink) { |p| p }
       expect do
         Bundler.with_clean_env { Brewdler::Commands::Dump.run }
       end.to_not raise_error


### PR DESCRIPTION
It's useful when running `brew brewdle dump --global --force` and ~/.Brewfile
is a symlink.